### PR TITLE
fix: remove src from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "types": "./dist/src/index.d.ts",
   "sideEffects": false,
   "files": [
-    "src",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
you don't need to publish src together with dist! This will only help increase `node_modules` size!

~squash please, I had a typo when I wrote the commit~